### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -164,23 +164,41 @@ class App {
     }
 
     leaderboardEl.style.display = '';
+    leaderboardEl.textContent = '';
 
-    const rows = topScores
-      .map(
-        (entry, i) =>
-          '<tr>' +
-          `<td class="lb-rank">${i + 1}</td>` +
-          `<td class="lb-name">${this._escapeHtml(entry.name)}</td>` +
-          `<td class="lb-score">${entry.score}</td>` +
-          '</tr>'
-      )
-      .join('');
+    const titleEl = document.createElement('h3');
+    titleEl.classList.add('lb-title');
+    titleEl.textContent = 'Top Scores';
 
-    leaderboardEl.innerHTML =
-      '<h3 class="lb-title">Top Scores</h3>' +
-      '<table class="lb-table" aria-label="Top 3 leaderboard">' +
-      `<tbody>${rows}</tbody>` +
-      '</table>';
+    const tableEl = document.createElement('table');
+    tableEl.classList.add('lb-table');
+    tableEl.setAttribute('aria-label', 'Top 3 leaderboard');
+
+    const tbodyEl = document.createElement('tbody');
+    topScores.forEach((entry, i) => {
+      const rowEl = document.createElement('tr');
+
+      const rankEl = document.createElement('td');
+      rankEl.classList.add('lb-rank');
+      rankEl.textContent = String(i + 1);
+
+      const nameEl = document.createElement('td');
+      nameEl.classList.add('lb-name');
+      nameEl.textContent = String(entry.name);
+
+      const scoreEl = document.createElement('td');
+      scoreEl.classList.add('lb-score');
+      scoreEl.textContent = String(entry.score);
+
+      rowEl.appendChild(rankEl);
+      rowEl.appendChild(nameEl);
+      rowEl.appendChild(scoreEl);
+      tbodyEl.appendChild(rowEl);
+    });
+
+    tableEl.appendChild(tbodyEl);
+    leaderboardEl.appendChild(titleEl);
+    leaderboardEl.appendChild(tableEl);
   }
 
   /** Escape HTML special chars for safe innerHTML insertion. */


### PR DESCRIPTION
Potential fix for [https://github.com/dock108dev/mini-golf-break/security/code-scanning/13](https://github.com/dock108dev/mini-golf-break/security/code-scanning/13)

Best fix: stop using `innerHTML` for leaderboard rendering and build DOM nodes with `createElement`, assigning dynamic values via `textContent`. This preserves behavior while eliminating reinterpretation of stored/user-originated text as HTML.

In `src/main.js`, update `_renderMenuLeaderboard()`:
- Remove `rows` HTML string construction.
- Remove `leaderboardEl.innerHTML = ...`.
- Clear container safely (`leaderboardEl.textContent = ''`).
- Create and append:
  - `<h3 class="lb-title">Top Scores</h3>`
  - `<table class="lb-table" aria-label="Top 3 leaderboard"><tbody>...</tbody></table>`
  - For each score: `<tr><td class="lb-rank">...</td><td class="lb-name">...</td><td class="lb-score">...</td></tr>` using `textContent`.
- `_escapeHtml` can remain (unused) to avoid wider refactors; no dependency changes needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
